### PR TITLE
Add assists

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Version 0.1
 New Features
 ------------
 
-- ``dispatch_on`` type information is added to the ``_NumPyInfo`` object to
+- ``_NumPyInfo`` is renamed to ``_NumPyFuncOverloadInfo`` [#16]
+
+- ``dispatch_on`` type information is added to the ``_NumPyFuncOverloadInfo`` object to
   which it dispaches. [#21]
 
 - Arguments to ``TypeConstraint.validate_types`` (and subclasses) are now

--- a/README.rst
+++ b/README.rst
@@ -3,10 +3,9 @@ Overload ``NumPy`` functions
 
 Tools for implementing ``__array_function__`` on custom functions.
 
-Quick Worked Example
---------------------
 
-This is a simple example.
+Implementing an Overload
+------------------------
 
 First, some imports:
 
@@ -15,7 +14,7 @@ First, some imports:
     >>> import numpy as np
     >>> from overload_numpy import NumPyOverloader, NDFunctionMixin
 
-Now we can define a ``overload_numpy.NumPyOverloader`` instance:
+Now we can define a |NumPyOverloader| instance:
 
     >>> VEC_FUNCS = NumPyOverloader()
 
@@ -30,7 +29,7 @@ The overloads apply to an array wrapping class. Let's define one:
 Now ``numpy`` functions can be overloaded and registered for ``Vector1D``.
 
     >>> @VEC_FUNCS.implements(np.concatenate, Vector1D)
-    ... def concatenate(vec1ds: tuple[Vector1D, ...]) -> Vector1D:
+    ... def concatenate(vec1ds: 'tuple[Vector1D, ...]') -> Vector1D:
     ...     return Vector1D(np.concatenate(tuple(v.x for v in vec1ds)))
 
 Time to check this works:
@@ -40,7 +39,90 @@ Time to check this works:
     >>> newvec
     Vector1D(x=array([0, 1, 2, 0, 1, 2]))
 
-Great. Your turn!
+
+Dispatching Overloads for Subclasses
+------------------------------------
+
+What if we defined a subclass of ``Vector1D``?
+
+    >>> @dataclass
+    ... class Vector2D(Vector1D):
+    ...     '''A simple 2-array wrapper.'''
+    ...     y: np.ndarray
+
+The overload for :func:`numpy.concatenate` registered on ``Vector1D`` will not
+work correctly for ``Vector2D``. However,
+:class:`~overload_numpy.NumPyOverloader` supports single-dispatch on the calling
+type for the overload, so overloads can be customized for subclasses.
+
+    >>> @VEC_FUNCS.implements(np.concatenate, Vector2D)
+    ... def concatenate(vec2ds: 'tuple[Vector2D, ...]') -> Vector2D:
+    ...     print("using Vector2D implementation...")
+    ...     return Vector2D(np.concatenate(tuple(v.x for v in vec2ds)),
+    ...                     np.concatenate(tuple(v.y for v in vec2ds)))
+
+Checking this works:
+
+    >>> vec2d = Vector2D(np.arange(3), np.arange(3, 6))
+    >>> newvec = np.concatenate((vec2d, vec2d))
+    using Vector2D implementation...
+    >>> newvec
+    Vector2D(x=array([0, 1, 2, 0, 1, 2]), y=array([3, 4, 5, 3, 4, 5]))
+
+
+Great! But rather than defining a new implementation for each
+subclass, let's see how we could write a more broadly applicable overload:
+
+    >>> from dataclasses import fields
+    >>> from typing import TypeVar
+    >>> V = TypeVar("V", bound="Vector1D")
+
+    >>> @VEC_FUNCS.implements(np.concatenate, Vector2D)  # overriding
+    ... def concatenate(vecs: 'tuple[V, ...]') -> V:
+    ...     VT = type(vecs[0])
+    ...     return VT(*(np.concatenate(tuple(getattr(v, f.name) for v in vecs))
+    ...                 for f in fields(VT)))
+
+Checking this works:
+
+    >>> newvec = np.concatenate((vec2d, vec2d))
+    >>> newvec
+    Vector2D(x=array([0, 1, 2, 0, 1, 2]), y=array([3, 4, 5, 3, 4, 5]))
+
+
+    >>> @dataclass
+    ... class Vector3D(Vector2D):
+    ...     '''A simple 3-array wrapper.'''
+    ...     z: np.ndarray
+
+    >>> vec3d = Vector3D(np.arange(2), np.arange(3, 5), np.arange(6, 8))
+    >>> newvec = np.concatenate((vec3d, vec3d))
+    >>> newvec
+    Vector3D(x=array([0, 1, 0, 1]), y=array([3, 4, 3, 4]), z=array([6, 7, 6, 7]))
+
+
+Assisting Groups of Overloads
+-----------------------------
+
+In the previous examples we wrote implementations for a single NumPy function. Overloading the full set of NumPy functions this way would take a long time.
+
+Wouldn't it be better if we could write many fewer, based on groups of NumPy functions.
+
+    >>> stack_funcs = {np.vstack, np.hstack, np.dstack, np.column_stack, np.row_stack}
+    >>> @VEC_FUNCS.assists(stack_funcs, types=Vector1D, dispatch_on=Vector1D)
+    ... def stack_assists(dispatch_on, func, vecs: tuple[Vector1D, ...], *args, **kwargs):
+    ...     cls = type(vecs[0])
+    ...     return cls(*(func(tuple(getattr(v, f.name) for v in vecs), *args, **kwargs)
+    ...                     for f in fields(cls)))
+
+Checking this works:
+
+    >>> np.vstack((vec1d, vec1d))
+    Vector1D(x=array([[0, 1, 2],
+                      [0, 1, 2]]))
+
+    >>> np.hstack((vec1d, vec1d))
+    Vector1D(x=array([0, 1, 2, 0, 1, 2]))
 
 
 Details

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,8 +73,12 @@ autoclass_content = "both"
 # This is added to the end of RST files - a good place to put substitutions to
 # be used globally.
 rst_epilog = """
-.. |NumPyOverloader| replace:: :class:`~overload_numpy.NumPyOverloader`
-"""
+.. |TypeConstraint| replace:: :class:`~overload_numpy.constraints.TypeConstraint`
+.. |_Dispatcher| replace:: :class:`~overload_numpy.dispatch._Dispatcher`
+.. |NumPyOverloader| replace:: :class:`~overload_numpy.overload.NumPyOverloader`
+
+.. |__array_function__| replace:: `__array_function__ https://numpy.org/doc/stable/reference/arrays.classes.html#numpy.class.__array_function__`_
+"""  # noqa: E501
 
 # intersphinx
 intersphinx_mapping = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,11 @@ autoclass_content = "both"
 # be used globally.
 rst_epilog = """
 .. |TypeConstraint| replace:: :class:`~overload_numpy.constraints.TypeConstraint`
-.. |_Dispatcher| replace:: :class:`~overload_numpy.dispatch._Dispatcher`
+.. |Invariant| replace:: :class:`~overload_numpy.constraints.Invariant`
+.. |Covariant| replace:: :class:`~overload_numpy.constraints.Covariant`
+.. |Contravariant| replace:: :class:`~overload_numpy.constraints.Contravariant`
+.. |Between| replace:: :class:`~overload_numpy.constraints.Between`
+
 .. |NumPyOverloader| replace:: :class:`~overload_numpy.overload.NumPyOverloader`
 
 .. |__array_function__| replace:: `__array_function__ https://numpy.org/doc/stable/reference/arrays.classes.html#numpy.class.__array_function__`_

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,19 @@
+.. _contributing:
+
+*****************
+How to contribute
+*****************
+
+We welcome contributions from anyone via pull requests on `GitHub
+<https://github.com/nstarman/overload_numpy>`_. If you don't feel comfortable
+modifying or adding functionality, we also welcome feature requests and bug
+reports as `GitHub issues <https://github.com/nstarman/overload_numpy/issues>`_.
+
+Developer documentation
+=======================
+
+.. toctree::
+    :maxdepth: 1
+
+    testing
+    docs

--- a/docs/docs.rst
+++ b/docs/docs.rst
@@ -1,0 +1,13 @@
+.. _overload_numpy-docs:
+
+=================
+Building the docs
+=================
+
+The documentation is built by Sphinx. To start, make sure you install all of the docs dependencies::
+
+    pip install -e ".[docs]"
+
+Then change directory into the ``docs/`` path. You now have to run the docs build::
+
+    make html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,10 +13,9 @@ Implementing an Overload
 First, some imports (and type hints):
 
     >>> from dataclasses import dataclass, fields
-    >>> from typing import ClassVar, TypeVar
+    >>> from typing import ClassVar
     >>> import numpy as np
     >>> from overload_numpy import NumPyOverloader, NDFunctionMixin
-    >>> V = TypeVar("V", bound="Vector1D")
 
 Now we can define a |NumPyOverloader| instance:
 
@@ -33,7 +32,7 @@ The overloads apply to an array wrapping class. Let's define one:
 Now ``numpy`` functions can be overloaded and registered for ``Vector1D``.
 
     >>> @VEC_FUNCS.implements(np.concatenate, Vector1D)
-    ... def concatenate(vec1ds: 'tuple[V, ...]') -> V:
+    ... def concatenate(vec1ds):
     ...     return Vector1D(np.concatenate(tuple(v.x for v in vec1ds)))
 
 Time to check this works:
@@ -60,7 +59,7 @@ work correctly for ``Vector2D``. However,
 type for the overload, so overloads can be customized for subclasses.
 
     >>> @VEC_FUNCS.implements(np.concatenate, Vector2D)
-    ... def concatenate(vec2ds: 'tuple[Vector2D, ...]') -> Vector2D:
+    ... def concatenate(vec2ds):
     ...     print("using Vector2D implementation...")
     ...     return Vector2D(np.concatenate(tuple(v.x for v in vec2ds)),
     ...                     np.concatenate(tuple(v.y for v in vec2ds)))
@@ -79,7 +78,7 @@ subclass, let's see how we could write a more broadly applicable overload:
 
     >>> @VEC_FUNCS.implements(np.concatenate, Vector1D)  # overriding both
     ... @VEC_FUNCS.implements(np.concatenate, Vector2D)  # overriding both
-    ... def concatenate(vecs: 'tuple[V, ...]') -> V:
+    ... def concatenate(vecs):
     ...     VT = type(vecs[0])
     ...     return VT(*(np.concatenate(tuple(getattr(v, f.name) for v in vecs))
     ...                 for f in fields(VT)))
@@ -109,11 +108,11 @@ In the previous examples we wrote implementations for a single NumPy function.
 Overloading the full set of NumPy functions this way would take a long time.
 
 Wouldn't it be better if we could write many fewer, based on groups of NumPy
-functions.
+functions?
 
     >>> stack_funcs = {np.vstack, np.hstack, np.dstack, np.column_stack, np.row_stack}
     >>> @VEC_FUNCS.assists(stack_funcs, types=Vector1D, dispatch_on=Vector1D)
-    ... def stack_assists(dispatch_on, func, vecs: tuple[V, ...], *args, **kwargs) -> V:
+    ... def stack_assists(dispatch_on, func, vecs, *args, **kwargs):
     ...     cls = type(vecs[0])
     ...     return cls(*(func(tuple(getattr(v, f.name) for v in vecs), *args, **kwargs)
     ...                     for f in fields(cls)))
@@ -126,3 +125,18 @@ Checking this works:
 
     >>> np.hstack((vec1d, vec1d))
     Vector1D(x=array([0, 1, 2, 0, 1, 2]))
+
+
+.. toctree::
+   :maxdepth: 1
+   :titlesonly:
+
+   install
+   contributing
+   src/index
+
+
+Contributors
+============
+
+.. include:: ../AUTHORS.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,21 +3,22 @@ Overload NumPy
 ##############
 
 
-Quick Worked Example
---------------------
+Implementing an Overload
+------------------------
 
 .. testsetup::
 
     >>> from __future__ import annotations
 
-First, some imports:
+First, some imports (and type hints):
 
-    >>> from dataclasses import dataclass
-    >>> from typing import ClassVar
+    >>> from dataclasses import dataclass, fields
+    >>> from typing import ClassVar, TypeVar
     >>> import numpy as np
     >>> from overload_numpy import NumPyOverloader, NDFunctionMixin
+    >>> V = TypeVar("V", bound="Vector1D")
 
-Now we can define a ``overload_numpy.NumPyOverloader`` instance:
+Now we can define a |NumPyOverloader| instance:
 
     >>> VEC_FUNCS = NumPyOverloader()
 
@@ -32,7 +33,7 @@ The overloads apply to an array wrapping class. Let's define one:
 Now ``numpy`` functions can be overloaded and registered for ``Vector1D``.
 
     >>> @VEC_FUNCS.implements(np.concatenate, Vector1D)
-    ... def concatenate(vec1ds: 'tuple[Vector1D, ...]') -> Vector1D:
+    ... def concatenate(vec1ds: 'tuple[V, ...]') -> V:
     ...     return Vector1D(np.concatenate(tuple(v.x for v in vec1ds)))
 
 Time to check this works:
@@ -43,8 +44,8 @@ Time to check this works:
     Vector1D(x=array([0, 1, 2, 0, 1, 2]))
 
 
-Overloading Subclasses
-----------------------
+Dispatching Overloads for Subclasses
+------------------------------------
 
 What if we defined a subclass of ``Vector1D``?
 
@@ -54,9 +55,9 @@ What if we defined a subclass of ``Vector1D``?
     ...     y: np.ndarray
 
 The overload for :func:`numpy.concatenate` registered on ``Vector1D`` will not
-work correctly for ``Vector2D``. :class:`~overload_numpy.NumPyOverloader`
-supports single-dispatch on the calling type for the overload, so overload can
-be customized for subclasses.
+work correctly for ``Vector2D``. However,
+:class:`~overload_numpy.NumPyOverloader` supports single-dispatch on the calling
+type for the overload, so overloads can be customized for subclasses.
 
     >>> @VEC_FUNCS.implements(np.concatenate, Vector2D)
     ... def concatenate(vec2ds: 'tuple[Vector2D, ...]') -> Vector2D:
@@ -73,18 +74,13 @@ Checking this works:
     Vector2D(x=array([0, 1, 2, 0, 1, 2]), y=array([3, 4, 5, 3, 4, 5]))
 
 
-That works great! But rather than defining a new implementation for each
+Great! But rather than defining a new implementation for each
 subclass, let's see how we could write a more broadly applicable overload:
 
-    >>> from dataclasses import fields
-    >>> from typing import TypeVar
-    >>> V = TypeVar("V", bound="Vector1D")
-
-    >>> @VEC_FUNCS.implements(np.concatenate, Vector2D)  # overriding
+    >>> @VEC_FUNCS.implements(np.concatenate, Vector1D)  # overriding both
+    ... @VEC_FUNCS.implements(np.concatenate, Vector2D)  # overriding both
     ... def concatenate(vecs: 'tuple[V, ...]') -> V:
     ...     VT = type(vecs[0])
-    ...     if not all(isinstance(v, VT) for v in vecs):  # make sure all 1 type
-    ...         return NotImplemented
     ...     return VT(*(np.concatenate(tuple(getattr(v, f.name) for v in vecs))
     ...                 for f in fields(VT)))
 
@@ -104,3 +100,29 @@ Checking this works:
     >>> newvec = np.concatenate((vec3d, vec3d))
     >>> newvec
     Vector3D(x=array([0, 1, 0, 1]), y=array([3, 4, 3, 4]), z=array([6, 7, 6, 7]))
+
+
+Assisting Groups of Overloads
+-----------------------------
+
+In the previous examples we wrote implementations for a single NumPy function.
+Overloading the full set of NumPy functions this way would take a long time.
+
+Wouldn't it be better if we could write many fewer, based on groups of NumPy
+functions.
+
+    >>> stack_funcs = {np.vstack, np.hstack, np.dstack, np.column_stack, np.row_stack}
+    >>> @VEC_FUNCS.assists(stack_funcs, types=Vector1D, dispatch_on=Vector1D)
+    ... def stack_assists(dispatch_on, func, vecs: tuple[V, ...], *args, **kwargs) -> V:
+    ...     cls = type(vecs[0])
+    ...     return cls(*(func(tuple(getattr(v, f.name) for v in vecs), *args, **kwargs)
+    ...                     for f in fields(cls)))
+
+Checking this works:
+
+    >>> np.vstack((vec1d, vec1d))
+    Vector1D(x=array([[0, 1, 2],
+                      [0, 1, 2]]))
+
+    >>> np.hstack((vec1d, vec1d))
+    Vector1D(x=array([0, 1, 2, 0, 1, 2]))

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,0 +1,60 @@
+.. include:: references.txt
+
+.. overload_numpy-install:
+
+************
+Installation
+************
+
+With ``pip`` (recommended)
+==========================
+
+To install the latest stable version using ``pip``, use
+
+.. code-block:: bash
+
+    python -m pip install overload_numpy
+
+This is the recommended way to install ``overload_numpy``.
+
+To install the development version
+
+.. code-block:: bash
+
+    python -m pip install git+https://github.com/nstarman/overload_numpy
+
+
+With ``conda``
+==============
+
+Conda is not yet supported.
+
+
+From Source: Cloning, Building, Installing
+==========================================
+
+The latest development version of overload_numpy can be cloned from `GitHub
+<https://github.com/>`_ using ``git``
+
+.. code-block:: bash
+
+    git clone git://github.com/nstarman/overload_numpy.git
+
+To build and install the project (from the root of the source tree, e.g., inside
+the cloned ``overload_numpy`` directory)
+
+.. code-block:: bash
+
+    python -m pip install [-e] .
+
+
+Python Dependencies
+===================
+
+This packages has the following dependencies:
+
+* `Python`_ >= 3.8
+
+Explicit version requirements are specified in the project `pyproject.toml
+<https://github.com/nstarman/overload_numpy/blob/main/pyproject.toml>`_. ``pip``
+and ``conda`` should install and enforce these versions automatically.

--- a/docs/src/constraints.rst
+++ b/docs/src/constraints.rst
@@ -1,0 +1,10 @@
+.. _constraints:
+
+###############################################
+Type Constraints (`overload_numpy.constraints`)
+###############################################
+
+API
+===
+
+.. automodapi:: overload_numpy.constraints

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,0 +1,18 @@
+.. _overload_numpy:
+
+#################################
+Overload NumPy (`overload_numpy`)
+#################################
+
+.. toctree::
+    :maxdepth: 1
+
+    constraints
+
+
+.. _overload_numpy-api:
+
+API
+===
+
+.. automodapi:: overload_numpy

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,0 +1,42 @@
+.. _overload_numpy-test:
+
+=================
+Running the tests
+=================
+
+The tests are written assuming they will be run with `tox
+<https://tox.readthedocs.io/en/latest/>`_ or `pytest <http://doc.pytest.org/>`_.
+
+To run the tests with tox, first make sure that tox is installed;
+::
+
+    pip install tox
+
+then run the basic test suite with:
+::
+
+    tox -e test
+
+or run the test suite with all optional dependencies with:
+::
+
+    tox -e test-alldeps
+
+You can see a list of available test environments with:
+::
+
+    tox -l -v
+
+which will also explain what each of them does.
+
+You can also run the tests directly with pytest. To do this, make sure to
+install the testing requirements (from the cloned ``overload_numpy`` repository
+directory)
+::
+
+    pip install -e ".[test]"
+
+Then you can run the tests with:
+::
+
+    pytest overload_numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@
   import_heading_stdlib = "STDLIB"
   import_heading_firstparty = "FIRSTPARTY"
   import_heading_thirdparty = "THIRDPARTY"
-  import_heading_localfolder = "LOCALFOLDER"
+  import_heading_localfolder = "LOCAL"
 
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,24 +171,6 @@
     ignore_errors = true
 
 
-[tool.pytest.ini_options]
-  testpaths = ["tests", "src/overload_numpy", "docs"]
-  astropy_header = "True"
-  doctest_plus = "enabled"
-  text_file_format = "rst"
-  addopts = "--doctest-rst"
-  markers = [
-    "incompatible_with_mypyc: run when testing mypyc compiled black"
-  ]
-  filterwarnings = [
-    # tomlkit
-    "ignore:The config value `project' has type `String', defaults to `str'.",
-    "ignore:The config value `htmlhelp_basename' has type `String', defaults to `str'.",
-    # distutils
-    "ignore:distutils Version classes are deprecated."
-  ]
-
-
 [tool.coverage.run]
   omit = [
     "*/overload_numpy/_astropy_init*",

--- a/setup.py
+++ b/setup.py
@@ -68,8 +68,8 @@ if not USE_MYPYC:
 else:
     print("BUILDING `overload_numpy` WITH MYPYC")
 
-    blocklist = [
-        # TODO!
+    blocklist = [  # TODO!
+        "overload_numpy/assists.py",  # https://github.com/python/mypy/issues/13304
         "overload_numpy/dispatch.py",  # https://github.com/python/mypy/issues/13613
     ]
     discovered: list[Path] = []

--- a/src/overload_numpy/__init__.py
+++ b/src/overload_numpy/__init__.py
@@ -1,6 +1,6 @@
-# LOCALFOLDER
-from overload_numpy import constraints  # noqa: F401, TC002
+# LOCAL
+from overload_numpy import constraints
 from overload_numpy.mixin import NDFunctionMixin
 from overload_numpy.overload import NumPyOverloader
 
-__all__ = ["NumPyOverloader", "NDFunctionMixin"]
+__all__ = ["NumPyOverloader", "NDFunctionMixin", "constraints"]

--- a/src/overload_numpy/assists.py
+++ b/src/overload_numpy/assists.py
@@ -41,4 +41,8 @@ class Assists(Generic[R]):
     dispatch_on: type[R]
 
     def __call__(self, *args: Any, **kwargs: Any) -> R:
+        """
+        Call the wrapped function, providing the dispatch type, :mod:`numpy`
+        function, and calling args and kwargs.
+        """
         return self.func(self.dispatch_on, self.implements, *args, **kwargs)

--- a/src/overload_numpy/assists.py
+++ b/src/overload_numpy/assists.py
@@ -1,0 +1,44 @@
+"""Assistance class for ``_NumPyInfo.func`` created by ``NumPyOverloads``.
+
+This is in a separate file because it cannot be mypc compiled:
+TODO! refactr when https://github.com/python/mypy/issues/13304 is fixed
+"""
+
+##############################################################################
+# IMPORTS
+
+from __future__ import annotations
+
+# STDLIB
+from dataclasses import dataclass
+from typing import Any, Callable, Generic, TypeVar, final
+
+__all__: list[str] = []
+
+
+##############################################################################
+# TYPING
+
+R = TypeVar("R")
+
+
+##############################################################################
+# CODE
+##############################################################################
+
+
+@final
+@dataclass(frozen=True)
+class Assists(Generic[R]):
+    """Info to overload a :mod:`numpy` function."""
+
+    func: Callable[..., R]
+    """The overloading function."""
+
+    implements: Callable[..., Any]
+    """The overloaded :mod:`numpy` function."""
+
+    dispatch_on: type[R]
+
+    def __call__(self, *args: Any, **kwargs: Any) -> R:
+        return self.func(self.dispatch_on, self.implements, *args, **kwargs)

--- a/src/overload_numpy/assists.py
+++ b/src/overload_numpy/assists.py
@@ -1,7 +1,7 @@
-"""Assistance class for ``_NumPyInfo.func`` created by ``NumPyOverloads``.
+"""Assistance class for ``_NumPyFuncOverloadInfo.func`` created by ``NumPyOverloads``.
 
 This is in a separate file because it cannot be mypc compiled:
-TODO! refactr when https://github.com/python/mypy/issues/13304 is fixed
+TODO! refactor when https://github.com/python/mypy/issues/13304 is fixed.
 """
 
 ##############################################################################
@@ -13,7 +13,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable, Generic, TypeVar, final
 
-__all__: list[str] = []
+__all__: list[str] = []  # nothing is public API
 
 
 ##############################################################################
@@ -29,20 +29,49 @@ R = TypeVar("R")
 
 @final
 @dataclass(frozen=True)
-class Assists(Generic[R]):
-    """Info to overload a :mod:`numpy` function."""
+class _Assists(Generic[R]):
+    """Info to overload a :mod:`numpy` function.
+
+    Parameters
+    ----------
+    func : Callable[..., R]
+        The assisting function. Must have signature:
+
+        .. code-block:: python
+
+            def func(dispatch_on, numpy_func, *args, **kwargs):
+                ...
+
+    implements : Callable[..., R]
+        The overloaded :mod:`numpy` function.
+    dispatch_on : type[R]
+        The type ``func`` returns.
+    """
 
     func: Callable[..., R]
     """The overloading function."""
 
+    dispatch_on: type[R]
+    """The type ``func`` returns."""
+
     implements: Callable[..., Any]
     """The overloaded :mod:`numpy` function."""
-
-    dispatch_on: type[R]
 
     def __call__(self, *args: Any, **kwargs: Any) -> R:
         """
         Call the wrapped function, providing the dispatch type, :mod:`numpy`
         function, and calling args and kwargs.
+
+        Parameters
+        ----------
+        *args : Any
+            Arguments into ``self.func``.
+        **kwargs : Any
+            Keyword arguments into ``self.func``.
+
+        Returns
+        -------
+        ``R``
+            The return output type of ``func``.
         """
         return self.func(self.dispatch_on, self.implements, *args, **kwargs)

--- a/src/overload_numpy/constraints.py
+++ b/src/overload_numpy/constraints.py
@@ -46,7 +46,7 @@ class TypeConstraint(metaclass=ABCMeta):
 
 
 @mypyc_attr(allow_interpreted_subclasses=True)
-@dataclass
+@dataclass(frozen=True)
 class Invariant(TypeConstraint):
     """Type constraint for invariance -- the exact type.
 

--- a/src/overload_numpy/constraints.py
+++ b/src/overload_numpy/constraints.py
@@ -18,7 +18,7 @@ __all__ = ["TypeConstraint", "Invariant", "Covariant", "Contravariant", "Between
 ##############################################################################
 
 
-@mypyc_attr(allow_interpreted_subclasses=True)
+@mypyc_attr(allow_interpreted_subclasses=True, serializable=True)
 class TypeConstraint(metaclass=ABCMeta):
     """ABC for constraining an argument type.
 
@@ -45,7 +45,7 @@ class TypeConstraint(metaclass=ABCMeta):
         """
 
 
-@mypyc_attr(allow_interpreted_subclasses=True)
+@mypyc_attr(allow_interpreted_subclasses=True, serializable=True)
 @dataclass(frozen=True)
 class Invariant(TypeConstraint):
     """Type constraint for invariance -- the exact type.
@@ -79,7 +79,7 @@ class Invariant(TypeConstraint):
         return arg_type is self.bound
 
 
-@mypyc_attr(allow_interpreted_subclasses=True)
+@mypyc_attr(allow_interpreted_subclasses=True, serializable=True)
 @dataclass(frozen=True)
 class Covariant(TypeConstraint):
     """A covariant constraint -- permitting subclasses.
@@ -114,7 +114,7 @@ class Covariant(TypeConstraint):
         return issubclass(arg_type, self.bound)
 
 
-@mypyc_attr(allow_interpreted_subclasses=True)
+@mypyc_attr(allow_interpreted_subclasses=True, serializable=True)
 @dataclass(frozen=True)
 class Contravariant(TypeConstraint):
     """A contravariant constraint -- permitting superclasses.
@@ -148,7 +148,7 @@ class Contravariant(TypeConstraint):
         return issubclass(self.bound, arg_type)
 
 
-@mypyc_attr(allow_interpreted_subclasses=True)
+@mypyc_attr(allow_interpreted_subclasses=True, serializable=True)
 @dataclass(frozen=True)
 class Between(TypeConstraint):
     """Type constrained between two types.

--- a/src/overload_numpy/dispatch.py
+++ b/src/overload_numpy/dispatch.py
@@ -7,8 +7,8 @@ from __future__ import annotations
 from functools import singledispatch
 from typing import TYPE_CHECKING, Any, NoReturn, final
 
-# LOCALFOLDER
-from overload_numpy.npinfo import _NOT_DISPATCHED, _NumPyInfo
+# LOCAL
+from overload_numpy.npinfo import _NOT_DISPATCHED, _NumPyFuncOverloadInfo
 
 if TYPE_CHECKING:
     # STDLIB
@@ -22,38 +22,38 @@ __all__: list[str] = []
 ##############################################################################
 
 
-# A stand-in function for a not-dispatched `_NumPyInfo`. If
-# `_NumPyInfo.validate_types` is used in `__array_function__` then this function
+# A stand-in function for a not-dispatched `_NumPyFuncOverloadInfo`. If
+# `_NumPyFuncOverloadInfo.validate_types` is used in `__array_function__` then this function
 # will never be called.
 def _notdispatched(*args: Any, **kwarg: Any) -> NoReturn:
     raise NotImplementedError("not dispatched")
 
 
-_notdispatched_info = _NumPyInfo(
+_notdispatched_info = _NumPyFuncOverloadInfo(
     func=_notdispatched, implements=_notdispatched, types=_NOT_DISPATCHED, dispatch_on=object
 )
-# The not-dispatched `_NumPyInfo`. All `_Dispatcher` start with this as the base
-# `_NumPyInfo`.
+# The not-dispatched `_NumPyFuncOverloadInfo`. All `_Dispatcher` start with this as the base
+# `_NumPyFuncOverloadInfo`.
 
 
 @final
 class _Dispatcher:
-    """Single dispatch."""
+    """`~functools.singledispatch` instance."""
 
     def __init__(self) -> None:
-        # Make default NotImplementedError _NumPyInfo
-        # This return value is necessary until the functional form of
-        # singledispatch works with MyPy for adding different return types.
-        # Until then this is restricted to the one return type.
-        # This cannot be built in mypyc v0.971
+        # Make default NotImplementedError
+        # `~overload_numpy.npinfo._NumPyFuncOverloadInfo` This return value is
+        # necessary until the functional form of singledispatch works with MyPy
+        # for adding different return types. Until then this is restricted to
+        # the one return type. This cannot be built in mypyc v0.971
         @singledispatch
-        def dispatcher(obj: object) -> _NumPyInfo:
+        def dispatcher(obj: object, /) -> _NumPyFuncOverloadInfo:
             return _notdispatched_info
 
-        self._dispatcher: functools._SingleDispatchCallable[_NumPyInfo]
+        self._dispatcher: functools._SingleDispatchCallable[_NumPyFuncOverloadInfo]
         self._dispatcher = dispatcher
 
-    def __call__(self, obj: object, /) -> _NumPyInfo:
-        """Get correct _NumPyInfo for the calling object's type."""
-        npinfo: _NumPyInfo = self._dispatcher(obj)
+    def __call__(self, obj: object, /) -> _NumPyFuncOverloadInfo:
+        """Get correct `~overload_numpy.npinfo._NumPyFuncOverloadInfo` for the calling object's type."""
+        npinfo: _NumPyFuncOverloadInfo = self._dispatcher(obj)
         return npinfo

--- a/src/overload_numpy/mixin.py
+++ b/src/overload_numpy/mixin.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, ClassVar, Collection
 from mypy_extensions import mypyc_attr
 
 if TYPE_CHECKING:
-    # LOCALFOLDER
+    # LOCAL
     from overload_numpy.constraints import TypeConstraint
     from overload_numpy.overload import NumPyOverloader
 

--- a/src/overload_numpy/mixin.py
+++ b/src/overload_numpy/mixin.py
@@ -26,11 +26,11 @@ class NDFunctionMixin:
 
     Attributes
     ----------
-    NP_FUNC_OVERLOADS : `overload_numpy.NumPyOverloader`
-        A class-attribute of an instance of ``NumPyOverloader``.
+    NP_FUNC_OVERLOADS : |NumPyOverloader|
+        A class-attribute of an instance of |NumPyOverloader|.
     NP_FUNC_TYPES : frozenset[type | TypeConstraint] | None, optional
         A class-attribute of `None` or a `frozenset` of `type` or
-        `overload_numpy.constraints.TypeConstraint`.
+        |TypeConstraint|.
 
     Examples
     --------

--- a/src/overload_numpy/mixin.py
+++ b/src/overload_numpy/mixin.py
@@ -20,9 +20,9 @@ if TYPE_CHECKING:
 ##############################################################################
 
 
-@mypyc_attr(allow_interpreted_subclasses=True)
+@mypyc_attr(allow_interpreted_subclasses=True, serializable=True)
 class NDFunctionMixin:
-    """Mixin for adding ``__array_function__``.
+    """Mixin for adding |__array_function__| to a class.
 
     Attributes
     ----------
@@ -34,14 +34,14 @@ class NDFunctionMixin:
 
     Examples
     --------
-    First, some imports:
+    First, some imports (and type hints):
 
-        >>> from dataclasses import dataclass
+        >>> from dataclasses import dataclass, fields
         >>> from typing import ClassVar
         >>> import numpy as np
         >>> from overload_numpy import NumPyOverloader, NDFunctionMixin
 
-    Now we can define a `overload_numpy.NumPyOverloader` instance:
+    Now we can define a |NumPyOverloader| instance:
 
         >>> VEC_FUNCS = NumPyOverloader()
 
@@ -53,10 +53,13 @@ class NDFunctionMixin:
         ...     x: np.ndarray
         ...     NP_FUNC_OVERLOADS: ClassVar[NumPyOverloader] = VEC_FUNCS
 
-    Now :mod:`numpy` functions can be overloaded and registered for ``Vector1D``.
+    Implementing an Overload
+    ^^^^^^^^^^^^^^^^^^^^^^^^
+    Now :mod:`numpy` functions can be overloaded and registered for
+    ``Vector1D``.
 
         >>> @VEC_FUNCS.implements(np.concatenate, Vector1D)
-        ... def concatenate(vec1ds: tuple[Vector1D, ...]) -> Vector1D:
+        ... def concatenate(vec1ds):
         ...     return Vector1D(np.concatenate(tuple(v.x for v in vec1ds)))
 
     Time to check this works:
@@ -66,21 +69,125 @@ class NDFunctionMixin:
         >>> newvec
         Vector1D(x=array([0, 1, 2, 0, 1, 2]))
 
-    Great!
+    Dispatching Overloads for Subclasses
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    What if we defined a subclass of ``Vector1D``?
+
+        >>> @dataclass
+        ... class Vector2D(Vector1D):
+        ...     '''A simple 2-array wrapper.'''
+        ...     y: np.ndarray
+
+    The overload for :func:`numpy.concatenate` registered on ``Vector1D`` will
+    not work correctly for ``Vector2D``. However, |NumPyOverloader| supports
+    single-dispatch on the calling type for the overload, so overloads can be
+    customized for subclasses.
+
+        >>> @VEC_FUNCS.implements(np.concatenate, Vector2D)
+        ... def concatenate2(vec2ds):
+        ...     print("using Vector2D implementation...")
+        ...     return Vector2D(np.concatenate(tuple(v.x for v in vec2ds)),
+        ...                     np.concatenate(tuple(v.y for v in vec2ds)))
+
+    Checking this works:
+
+        >>> vec2d = Vector2D(np.arange(3), np.arange(3, 6))
+        >>> newvec = np.concatenate((vec2d, vec2d))
+        using Vector2D implementation...
+        >>> newvec
+        Vector2D(x=array([0, 1, 2, 0, 1, 2]), y=array([3, 4, 5, 3, 4, 5]))
+
+
+    Great! But rather than defining a new implementation for each subclass,
+    let's see how we could write a more broadly applicable overload:
+
+        >>> @VEC_FUNCS.implements(np.concatenate, Vector1D)  # overriding both
+        ... @VEC_FUNCS.implements(np.concatenate, Vector2D)  # overriding both
+        ... def concatenate_general(vecs):
+        ...     VT = type(vecs[0])
+        ...     return VT(*(np.concatenate(tuple(getattr(v, f.name) for v in vecs))
+        ...                 for f in fields(VT)))
+
+    Checking this works:
+
+        >>> newvec = np.concatenate((vec2d, vec2d))
+        >>> newvec
+        Vector2D(x=array([0, 1, 2, 0, 1, 2]), y=array([3, 4, 5, 3, 4, 5]))
+
+
+        >>> @dataclass
+        ... class Vector3D(Vector2D):
+        ...     '''A simple 3-array wrapper.'''
+        ...     z: np.ndarray
+
+        >>> vec3d = Vector3D(np.arange(2), np.arange(3, 5), np.arange(6, 8))
+        >>> newvec = np.concatenate((vec3d, vec3d))
+        >>> newvec
+        Vector3D(x=array([0, 1, 0, 1]), y=array([3, 4, 3, 4]), z=array([6, 7, 6, 7]))
+
+    Assisting Groups of Overloads
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    In the previous examples we wrote implementations for a single NumPy
+    function. Overloading the full set of NumPy functions this way would take a
+    long time.
+
+    Wouldn't it be better if we could write many fewer, based on groups of NumPy
+    functions.
+
+        >>> stack_funcs = {np.vstack, np.hstack, np.dstack, np.column_stack, np.row_stack}
+        >>> @VEC_FUNCS.assists(stack_funcs, types=Vector1D, dispatch_on=Vector1D)
+        ... def stack_assists(dispatch_on, func, vecs, *args, **kwargs):
+        ...     cls = type(vecs[0])
+        ...     return cls(*(func(tuple(getattr(v, f.name) for v in vecs), *args, **kwargs)
+        ...                     for f in fields(cls)))
+
+    Checking this works:
+
+        >>> np.vstack((vec1d, vec1d))
+        Vector1D(x=array([[0, 1, 2],
+                          [0, 1, 2]]))
+
+        >>> np.hstack((vec1d, vec1d))
+        Vector1D(x=array([0, 1, 2, 0, 1, 2]))
     """
 
     NP_FUNC_OVERLOADS: ClassVar[NumPyOverloader]
+    """A class-attribute of an instance of |NumPyOverloader|."""
+
     NP_FUNC_TYPES: ClassVar[frozenset[type | TypeConstraint] | None] = frozenset()
-    # empty frozenset -> self type.
+    """
+    A class-attribute of `None` or a `frozenset` of `type` / |TypeConstraint|.
+    """
 
     def __array_function__(
         self, func: Callable[..., Any], types: Collection[type], args: tuple[Any, ...], kwargs: dict[str, Any]
     ) -> Any:
-        # Check if can be dispatched
+        """|__array_function__|.
+
+        Parameters
+        ----------
+        func : Callable[..., Any]
+            The overloaded :mod:`numpy` function.
+        types : Collection[type]
+            ``types`` is a collection collections.abc.Collection of unique
+            argument types from the original NumPy function call that implement
+            |__array_function__|.
+        args : tuple[Any, ...]
+            The tuple args are directly passed on from the original call.
+        kwargs : dict[str, Any]
+            The dict kwargs are directly passed on from the original call.
+
+        Returns
+        -------
+        Any
+            The result of calling the overloaded functions.
+        """
+        # Check if can be dispatched.
         if func not in self.NP_FUNC_OVERLOADS:
             return NotImplemented
 
-        # Get _NumPyInfo on function, given type of self
+        # Get _NumPyFuncOverloadInfo on function, given type of self.
         finfo = self.NP_FUNC_OVERLOADS[func](self)
 
         # Note: this allows subclasses that don't override `__array_function__`
@@ -91,6 +198,6 @@ class NDFunctionMixin:
         if not finfo.validate_types(types):
             return NotImplemented
 
-        # TODO! validate args and kwargs.
+        # TODO! validation for args and kwargs.
 
-        return finfo.func(*args, **kwargs)
+        return finfo.func(*args, **kwargs)  # returns the result or NotImplemented

--- a/src/overload_numpy/npinfo.py
+++ b/src/overload_numpy/npinfo.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, TypeVar, final
 # THIRDPARTY
 from mypy_extensions import mypyc_attr
 
-# LOCALFOLDER
+# LOCAL
 from overload_numpy.constraints import TypeConstraint
 
 __all__: list[str] = []

--- a/src/overload_numpy/npinfo.py
+++ b/src/overload_numpy/npinfo.py
@@ -30,6 +30,7 @@ Self = TypeVar("Self")
 
 
 @mypyc_attr(allow_interpreted_subclasses=True)
+@dataclass(frozen=True)
 class _NotDispatched(TypeConstraint):
     """A TypeConstraint that always validates to `False`.
 
@@ -40,7 +41,7 @@ class _NotDispatched(TypeConstraint):
         should be deprecated in favor of `NotImplemented` as the special flag.
     """
 
-    def validate_type(self, arg_type: type) -> bool:
+    def validate_type(self, arg_type: type, /) -> bool:
         return False  # never true
 
 

--- a/src/overload_numpy/npinfo.py
+++ b/src/overload_numpy/npinfo.py
@@ -29,7 +29,7 @@ Self = TypeVar("Self")
 ##############################################################################
 
 
-@mypyc_attr(allow_interpreted_subclasses=True)
+@mypyc_attr(allow_interpreted_subclasses=True, serializable=True)
 @dataclass(frozen=True)
 class _NotDispatched(TypeConstraint):
     """A TypeConstraint that always validates to `False`.
@@ -53,8 +53,26 @@ _NOT_DISPATCHED = _NotDispatched()
 
 @final
 @dataclass(frozen=True)
-class _NumPyInfo:
-    """Info to overload a :mod:`numpy` function."""
+class _NumPyFuncOverloadInfo:
+    """Info to overload a :mod:`numpy` function.
+
+    Parameters
+    ----------
+    func : Callable[..., Any]
+        The overloading function.
+    implements
+        The overloaded :mod:`numpy` function.
+    types: TypeConstraint or Collection[TypeConstraint]
+        The argument types for the overloaded function.
+        Used to check if the overload is valid.
+    dispatch_on: type
+        The type dispatched on. See `~overload_numpy.dispatch._Dispatcher`.
+
+    Methods
+    -------
+    validate_types
+        Check the types of the arguments.
+    """
 
     func: Callable[..., Any]
     """The overloading function."""
@@ -62,12 +80,11 @@ class _NumPyInfo:
     implements: Callable[..., Any]
     """The overloaded :mod:`numpy` function."""
 
+    # TODO! when py3.10+ add NotImplemented
     types: TypeConstraint | Collection[TypeConstraint]
     """
     The argument types for the overloaded function.
     Used to check if the overload is valid.
-
-    :todo: py3.10+ add NotImplemented
     """
 
     dispatch_on: type
@@ -121,5 +138,9 @@ class _NumPyInfo:
             return True
 
     def __call__(self: Self, *args: Any) -> Self:
-        """Return self. Used for singledispatch in _Dispatcher."""
+        """Return self.
+
+        Used for `~functools.singledispatch` in
+        `~overload_numpy.dispatch._Dispatcher`.
+        """
         return self

--- a/src/overload_numpy/overload.py
+++ b/src/overload_numpy/overload.py
@@ -4,15 +4,33 @@
 from __future__ import annotations
 
 # STDLIB
+from abc import ABCMeta
 from collections.abc import Collection
-from typing import Any, Callable, Final, Iterator, KeysView, Mapping, ValuesView
+from dataclasses import dataclass
+from typing import (
+    Any,
+    Callable,
+    Final,
+    Iterator,
+    KeysView,
+    Mapping,
+    TypeVar,
+    ValuesView,
+)
 
 # LOCALFOLDER
+from overload_numpy.assists import Assists
 from overload_numpy.constraints import Covariant, TypeConstraint
 from overload_numpy.dispatch import _Dispatcher
 from overload_numpy.npinfo import _NumPyInfo
 
 __all__: list[str] = []
+
+##############################################################################
+# TYPING
+
+C = TypeVar("C", bound=Callable[..., Any])
+R = TypeVar("R")
 
 
 ##############################################################################
@@ -116,7 +134,7 @@ class NumPyOverloader(Mapping[Callable[..., Any], _Dispatcher]):
         dispatch_on: type,
         *,
         types: type | TypeConstraint | Collection[type | TypeConstraint] | None = None,
-    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    ) -> ImplementsDecorator:
         """Register an __array_function__ implementation object.
 
         This is a decorator factory, returning ``decorator``, which registers
@@ -142,45 +160,75 @@ class NumPyOverloader(Mapping[Callable[..., Any], _Dispatcher]):
         decorator : callable[[callable], callable]
             Function to register a wrapped function.
         """
+        return ImplementsDecorator(self, numpy_func=numpy_func, types=types, dispatch_on=dispatch_on)
+
+    def assists(
+        self,
+        numpy_func: Callable[..., Any],
+        /,
+        dispatch_on: type,
+        *,
+        types: type | TypeConstraint | Collection[type | TypeConstraint] | None = None,
+    ) -> AssistsDecorator:
+        # - TODO! make it work on many numpy funcs
+        return AssistsDecorator(self, numpy_func=numpy_func, types=types, dispatch_on=dispatch_on)
+
+
+##############################################################################
+# Decorators for implementations
+
+
+@dataclass(frozen=True)
+class OverloadDecoratorBase(metaclass=ABCMeta):
+
+    overloader: NumPyOverloader
+    numpy_func: Callable[..., Any]
+    types: type | TypeConstraint | Collection[type | TypeConstraint] | None
+    dispatch_on: type
+
+    def __post_init__(self) -> None:
         # Make single-dispatcher for numpy function
-        if numpy_func not in self._reg:
-            self._reg[numpy_func] = _Dispatcher()
+        if self.numpy_func not in self.overloader._reg:
+            self.overloader._reg[self.numpy_func] = _Dispatcher()
 
-        def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
-            """Add function to numpy overloading.
+    # @abstractmethod  # TODO: fix when https://github.com/python/mypy/issues/5374 released
+    def _func_hook(self, func: Callable[..., Any]) -> Callable[..., Any]:
+        raise NotImplementedError
 
-            Parameters
-            ----------
-            func : Callable[..., Any]
-                The function.
+    def __call__(self, func: C) -> C:
+        # TODO? infer dispatch_on from 1st argument
+        # if dispatch_on is None:  # Get from 1st argument
+        #     argname, dispatch_type = next(iter(get_type_hints(func).items()))
+        #     if not _is_valid_dispatch_type(dispatch_type):
+        #         raise TypeError(
+        #             f"Invalid annotation for {argname!r}. "
+        #             f"{dispatch_type!r} is not a class."
+        #         )
+        # else:
+        #     dispatch_type = dispatch_on
 
-            Returns
-            -------
-            func : Callable[..., Any]
-                Same as ``func``.
-            """
-            # TODO? infer dispatch_on from 1st argument
-            # if dispatch_on is None:  # Get from 1st argument
-            #     argname, dispatch_type = next(iter(get_type_hints(func).items()))
-            #     if not _is_valid_dispatch_type(dispatch_type):
-            #         raise TypeError(
-            #             f"Invalid annotation for {argname!r}. "
-            #             f"{dispatch_type!r} is not a class."
-            #         )
-            # else:
-            #     dispatch_type = dispatch_on
-            dispatch_type = dispatch_on
+        # Turn ``types`` into only TypeConstraint
+        tinfo = self.overloader._parse_types(self.types, self.dispatch_on)
+        # Note: I don't think types cannot be inferred from the function
+        # because NumPy uses a dispatcher object to get the
+        # ``relevant_args``.
 
-            # Turn ``types`` into only TypeConstraint
-            tinfo = self._parse_types(types, dispatch_type)
-            # Note: I don't think types cannot be inferred from the function
-            # because NumPy uses a dispatcher object to get the
-            # ``relevant_args``.
+        # Adding a new numpy function
+        info = _NumPyInfo(
+            func=self._func_hook(func), types=tinfo, implements=self.numpy_func, dispatch_on=self.dispatch_on
+        )
+        # Register the function
+        self.overloader._reg[self.numpy_func]._dispatcher.register(self.dispatch_on, info)
+        return func
 
-            # Adding a new numpy function
-            info = _NumPyInfo(func=func, types=tinfo, implements=numpy_func, dispatch_on=dispatch_on)
-            # Register the function
-            self._reg[numpy_func]._dispatcher.register(dispatch_type, info)
-            return func
 
-        return decorator
+@dataclass(frozen=True)
+class ImplementsDecorator(OverloadDecoratorBase):
+    def _func_hook(self, func: C) -> C:
+        return func
+
+
+@dataclass(frozen=True)
+class AssistsDecorator(OverloadDecoratorBase):
+    def _func_hook(self, func: Callable[..., R]) -> Assists[R]:
+        return Assists(func=func, implements=self.numpy_func, dispatch_on=self.dispatch_on)

--- a/src/overload_numpy/overload.py
+++ b/src/overload_numpy/overload.py
@@ -18,11 +18,11 @@ from typing import (
     ValuesView,
 )
 
-# LOCALFOLDER
-from overload_numpy.assists import Assists
+# LOCAL
+from overload_numpy.assists import _Assists
 from overload_numpy.constraints import Covariant, TypeConstraint
 from overload_numpy.dispatch import _Dispatcher
-from overload_numpy.npinfo import _NumPyInfo
+from overload_numpy.npinfo import _NumPyFuncOverloadInfo
 
 __all__: list[str] = []
 
@@ -39,9 +39,56 @@ R = TypeVar("R")
 
 
 class NumPyOverloader(Mapping[Callable[..., Any], _Dispatcher]):
-    """Overload :mod:`numpy` functions in ``__array_function__``."""
+    """Overload :mod:`numpy` functions with |__array_function__|.
+
+    Parameters
+    ----------
+    _reg : dict[Callable, |`~overload_numpy.dispatch._Dispatcher`|], optional
+        Registry of overloaded functions. You probably don't want to pass this
+        as a parameter.
+
+    Examples
+    --------
+    First, some imports:
+
+        >>> from __future__ import annotations
+        >>> from dataclasses import dataclass, fields
+        >>> from typing import ClassVar
+        >>> import numpy as np
+        >>> from overload_numpy import NumPyOverloader, NDFunctionMixin
+
+    Now we can define a |NumPyOverloader| instance:
+
+        >>> VEC_FUNCS = NumPyOverloader()
+
+    The overloads apply to an array wrapping class. Let's define one:
+
+        >>> @dataclass
+        ... class Vector1D(NDFunctionMixin):
+        ...     '''A simple array wrapper.'''
+        ...     x: np.ndarray
+        ...     NP_FUNC_OVERLOADS: ClassVar[NumPyOverloader] = VEC_FUNCS
+
+    Now ``numpy`` functions can be overloaded and registered for ``Vector1D``.
+
+        >>> @VEC_FUNCS.implements(np.concatenate, Vector1D)
+        ... def concatenate(vecs):
+        ...     VT = type(vecs[0])
+        ...     return VT(*(np.concatenate(tuple(getattr(v, f.name) for v in vecs))
+        ...                 for f in fields(VT)))
+
+    Time to check this works:
+
+        >>> vec1d = Vector1D(np.arange(3))
+        >>> np.concatenate((vec1d, vec1d))
+        Vector1D(x=array([0, 1, 2, 0, 1, 2]))
+    """
 
     _reg: Final[dict[Callable[..., Any], _Dispatcher]] = {}
+    """Registry of overloaded functions.
+
+    You probably don't want to pass this as a parameter.
+    """
 
     # ===============================================================
     # Mapping
@@ -78,7 +125,7 @@ class NumPyOverloader(Mapping[Callable[..., Any], _Dispatcher]):
         ----------
         types : type or TypeConstraint or Collection[type | TypeConstraint] or
         None
-            The types for argument ``types`` in ``__array_function__``. If
+            The types for argument ``types`` in |__array_function__|. If
             `None`, then ``dispatch_type`` must have class-level attribute
             ``NP_FUNC_TYPES`` that is a `frozenset` of `type` or
             `overload_numpy.constraints.TypeConstraint`.
@@ -110,12 +157,10 @@ class NumPyOverloader(Mapping[Callable[..., Any], _Dispatcher]):
                     f"if types is None ``{dispatch_type}.NP_FUNC_TYPES`` must be frozenset[types | TypeConstraint]"
                 )
 
-            ts = frozenset({dispatch_type} | ts)  # Add self type!
+            ts = frozenset({dispatch_type} | ts)  # Adds self type!
 
         # Turn `types` into only TypeConstraint
         parsed: frozenset[TypeConstraint]
-        # if types == "self":
-        #     parsed = frozenset((Covariant(dispatch_type),))
         if isinstance(ts, TypeConstraint):
             parsed = frozenset((ts,))
         elif isinstance(ts, type):
@@ -134,8 +179,8 @@ class NumPyOverloader(Mapping[Callable[..., Any], _Dispatcher]):
         dispatch_on: type,
         *,
         types: type | TypeConstraint | Collection[type | TypeConstraint] | None = None,
-    ) -> ImplementsDecorator:
-        """Register an __array_function__ implementation object.
+    ) -> _ImplementsDecorator:
+        """Register an |__array_function__| implementation object.
 
         This is a decorator factory, returning ``decorator``, which registers
         the decorated function as an overload method for :mod:`numpy` function
@@ -151,27 +196,122 @@ class NumPyOverloader(Mapping[Callable[..., Any], _Dispatcher]):
         types : type or TypeConstraint or Collection thereof or None,
         keyword-only
             The types of the arguments of `numpy_func`. See
-            https://numpy.org/doc/stable/reference/arrays.classes.html#numpy.class.__array_function__
+            |__array_function__|
             If `None` then ``dispatch_on`` must have class-level attribute
             ``NP_FUNC_TYPES`` specifying the types.
 
         Returns
         -------
-        decorator : callable[[callable], callable]
-            Function to register a wrapped function.
+        `~overload_numpy.overload._ImplementsDecorator`
+            Decorator to register the wrapped function.
+
+        Examples
+        --------
+        There's a fair bit of setup required:
+
+            >>> from dataclasses import dataclass, fields
+            >>> from typing import ClassVar
+            >>> import numpy as np
+            >>> from overload_numpy import NumPyOverloader, NDFunctionMixin
+
+            >>> VEC_FUNCS = NumPyOverloader()
+
+            >>> @dataclass
+            ... class Vector1D(NDFunctionMixin):
+            ...     '''A simple array wrapper.'''
+            ...     x: np.ndarray
+            ...     NP_FUNC_OVERLOADS: ClassVar[NumPyOverloader] = VEC_FUNCS
+
+        Now we can register an ``implements`` functions.
+
+            >>> @VEC_FUNCS.implements(np.concatenate, Vector1D)  # overriding
+            ... def concatenate(vecs):
+            ...     VT = type(vecs[0])
+            ...     return VT(*(np.concatenate(tuple(getattr(v, f.name) for v in vecs))
+            ...                 for f in fields(VT)))
+
+        Checking it works:
+
+            >>> vec1d = Vector1D(np.arange(3))
+
+            >>> newvec = np.concatenate((vec1d, vec1d))
+            >>> newvec
+            Vector2D(x=array([0, 1, 2, 0, 1, 2]), y=array([3, 4, 5, 3, 4, 5]))
         """
-        return ImplementsDecorator(self, numpy_func=numpy_func, types=types, dispatch_on=dispatch_on)
+        return _ImplementsDecorator(self, numpy_func=numpy_func, types=types, dispatch_on=dispatch_on)
 
     def assists(
         self,
-        numpy_func: Callable[..., Any],
+        numpy_funcs: Callable[..., Any] | set[Callable[..., Any]],
         /,
         dispatch_on: type,
         *,
         types: type | TypeConstraint | Collection[type | TypeConstraint] | None = None,
-    ) -> AssistsDecorator:
-        # - TODO! make it work on many numpy funcs
-        return AssistsDecorator(self, numpy_func=numpy_func, types=types, dispatch_on=dispatch_on)
+    ) -> _AssistsManyDecorator:
+        """Register an |__array_function__| assistance function.
+
+        This is a decorator factory, returning ``decorator``, which registers
+        the decorated function as an overload method for :mod:`numpy` function
+        ``numpy_func`` for a class of type ``dispatch_on``.
+
+        Parameters
+        ----------
+        numpy_func : callable[..., Any], positional-only
+            The :mod:`numpy` function that is being overloaded.
+        dispatch_on : type
+            The class type for which the overload implementation is being
+            registered.
+        types : type or TypeConstraint or Collection thereof or None,
+        keyword-only
+            The types of the arguments of `numpy_func`. See
+            |__array_function__|
+            If `None` then ``dispatch_on`` must have class-level attribute
+            ``NP_FUNC_TYPES`` specifying the types.
+
+        Returns
+        -------
+        `~overload_numpy.overload._AssistsManyDecorator`
+            Decorator to register the wrapped function(s).
+            This decorator should never be called by the user.
+
+        Examples
+        --------
+        There's a fair bit of setup required:
+
+            >>> from dataclasses import dataclass, fields
+            >>> from typing import ClassVar
+            >>> import numpy as np
+            >>> from overload_numpy import NumPyOverloader, NDFunctionMixin
+
+            >>> VEC_FUNCS = NumPyOverloader()
+
+            >>> @dataclass
+            ... class Vector1D(NDFunctionMixin):
+            ...     '''A simple array wrapper.'''
+            ...     x: np.ndarray
+            ...     NP_FUNC_OVERLOADS: ClassVar[NumPyOverloader] = VEC_FUNCS
+
+        Now we can register ``assists`` functions.
+
+            >>> stack_funcs = {np.vstack, np.hstack, np.dstack, np.column_stack, np.row_stack}
+            >>> @VEC_FUNCS.assists(stack_funcs, types=Vector1D, dispatch_on=Vector1D)
+            ... def stack_assists(dispatch_on, func, vecs, *args, **kwargs):
+            ...     cls = type(vecs[0])
+            ...     return cls(*(func(tuple(getattr(v, f.name) for v in vecs), *args, **kwargs)
+            ...                     for f in fields(cls)))
+
+        Checking it worked:
+
+            >>> assert np.vstack in VEC_FUNCS
+            True
+        """
+        # Make ``numpy_funcs`` into a set[``numpy_func``]
+        setnpfs = numpy_funcs if isinstance(numpy_funcs, set) else {numpy_funcs}
+
+        # Return
+        return _AssistsManyDecorator(
+            _AssistsDecorator(self, numpy_func=npf, types=types, dispatch_on=dispatch_on) for npf in setnpfs
+        )
 
 
 ##############################################################################
@@ -179,7 +319,25 @@ class NumPyOverloader(Mapping[Callable[..., Any], _Dispatcher]):
 
 
 @dataclass(frozen=True)
-class OverloadDecoratorBase(metaclass=ABCMeta):
+class _OverloadDecoratorBase(metaclass=ABCMeta):
+    """Decorator base class for registering an |__array_function__| overload.
+
+    Instances of this class should not be used directly.
+
+    Parameters
+    ----------
+    overloader : `~overload_numpy.overload.NumPyOverloader`
+        Overloader instance.
+    numpy_func : Callable[..., Any]
+        The :mod:`numpy` function that is being overloaded.
+    types : type or TypeConstraint or Collection thereof or None
+        The types of the arguments of `numpy_func`. See |__array_function__| If
+        `None` then ``dispatch_on`` must have class-level attribute
+        ``NP_FUNC_TYPES`` specifying the types.
+    dispatch_on : type
+            The class type for which the overload implementation is being
+            registered.
+    """
 
     overloader: NumPyOverloader
     numpy_func: Callable[..., Any]
@@ -191,11 +349,55 @@ class OverloadDecoratorBase(metaclass=ABCMeta):
         if self.numpy_func not in self.overloader._reg:
             self.overloader._reg[self.numpy_func] = _Dispatcher()
 
+        # Turn ``types`` into only TypeConstraint
+        self.overloader._parse_types(self.types, self.dispatch_on)
+
     # @abstractmethod  # TODO: fix when https://github.com/python/mypy/issues/5374 released
-    def func_hook(self, func: Callable[..., Any]) -> Callable[..., Any]:
+    def func_hook(self, func: Callable[..., Any], /) -> Callable[..., Any]:
+        """Function hook.
+
+        Parameters
+        ----------
+        func : Callable[..., Any], positional-only
+            The overloading function.
+
+        Returns
+        -------
+        Callable[..., Any]
+            How the function is overloaded. In ``_ImplementsDecorator`` this just
+            returns ``func``. In ``_AssistsDecorator`` this creates an
+            `~overload_numpy.assists._Assists`.
+
+        Raises
+        ------
+        NotImplementedError
+            This function must be overwritten in child classes.
+        """
         raise NotImplementedError
 
-    def __call__(self, func: C) -> C:
+    def __call__(self, func: C, /) -> C:
+        """Register an |__array_function__| overload.
+
+        Parameters
+        ----------
+        func : Callable[..., Any]
+            The :mod:`numpy` function to overload.
+
+        Returns
+        -------
+        func : Callable[..., Any]
+            The same as the input``func``.
+
+        Raises
+        ------
+        ValueError
+            If ``self.types`` is the wrong type.
+        AttributeError
+            If ``types`` is `None` and ``dispatch_type`` does not have an
+            attribute ``NP_FUNC_TYPES``.
+            If ``dispatch_type.NP_FUNC_TYPES`` is not a `frozenset` of `type` or
+            `overload_numpy.constraints.TypeConstraint
+        """
         # TODO? infer dispatch_on from 1st argument
         # if dispatch_on is None:  # Get from 1st argument
         #     argname, dispatch_type = next(iter(get_type_hints(func).items()))
@@ -214,7 +416,7 @@ class OverloadDecoratorBase(metaclass=ABCMeta):
         # ``relevant_args``.
 
         # Adding a new numpy function
-        info = _NumPyInfo(
+        info = _NumPyFuncOverloadInfo(
             func=self.func_hook(func), types=tinfo, implements=self.numpy_func, dispatch_on=self.dispatch_on
         )
         # Register the function
@@ -223,12 +425,94 @@ class OverloadDecoratorBase(metaclass=ABCMeta):
 
 
 @dataclass(frozen=True)
-class ImplementsDecorator(OverloadDecoratorBase):
-    def func_hook(self, func: C) -> C:
+class _ImplementsDecorator(_OverloadDecoratorBase):
+    """Decorator for registering with `~overload_numpy.NumPyOverloader`.
+
+    Instances of this class should not be used directly.
+
+    Parameters
+    ----------
+    overloader : `~overload_numpy.overload.NumPyOverloader`
+        Overloader instance.
+    numpy_func : Callable[..., Any]
+        The :mod:`numpy` function that is being overloaded.
+    types : type or TypeConstraint or Collection thereof or None
+        The types of the arguments of `numpy_func`. See |__array_function__| If
+        `None` then ``dispatch_on`` must have class-level attribute
+        ``NP_FUNC_TYPES`` specifying the types.
+    dispatch_on : type
+            The class type for which the overload implementation is being
+            registered.
+
+    Methods
+    -------
+    func_hook
+        Returns the input ``func`` unchanged.
+    """
+
+    def func_hook(self, func: C, /) -> C:
         return func
 
 
 @dataclass(frozen=True)
-class AssistsDecorator(OverloadDecoratorBase):
-    def func_hook(self, func: Callable[..., R]) -> Assists[R]:
-        return Assists(func=func, implements=self.numpy_func, dispatch_on=self.dispatch_on)
+class _AssistsDecorator(_OverloadDecoratorBase):
+    """Decorator for registering with `~overload_numpy.NumPyOverloader`.
+
+    Instances of this class should not be used directly.
+
+    Parameters
+    ----------
+    overloader : `~overload_numpy.overload.NumPyOverloader`
+        Overloader instance.
+    numpy_func : Callable[..., Any]
+        The :mod:`numpy` function that is being overloaded.
+    types : type or TypeConstraint or Collection thereof or None
+        The types of the arguments of `numpy_func`. See |__array_function__| If
+        `None` then ``dispatch_on`` must have class-level attribute
+        ``NP_FUNC_TYPES`` specifying the types.
+    dispatch_on : type
+            The class type for which the overload implementation is being
+            registered.
+
+    Methods
+    -------
+    func_hook
+        Returns the input ``func`` as an `~overload_numpy.assists._Assists` object.
+    """
+
+    def func_hook(self, func: Callable[..., R], /) -> _Assists[R]:
+        return _Assists(func=func, implements=self.numpy_func, dispatch_on=self.dispatch_on)
+
+
+@dataclass(frozen=True)
+class _AssistsManyDecorator:
+    """Decorator for registering many `~overload_numpy.NumPyOverloader.assists` functions.
+
+    Parameters
+    ----------
+    _iterator : Iterator[_AssistsDecorator]
+        Iterator of ``_AssistsDecorator``.
+    """
+
+    _iterator: Iterator[_AssistsDecorator]
+    """Iterator of ``_AssistsDecorator``."""
+
+    def __call__(self, func: C, /) -> C:
+        """Decorate and return ``func``.
+
+        Parameters
+        ----------
+        func : Callable[..., R]
+            Assistance function.
+
+        Returns
+        -------
+        func : Callable[..., R]
+            Same as ``func``.
+        """
+        # Iterate through ``self._iterator``, calling the contained
+        # ``_AssistsDecorator``.
+        for obj in self._iterator:
+            obj(func)
+
+        return func

--- a/src/overload_numpy/overload.py
+++ b/src/overload_numpy/overload.py
@@ -192,7 +192,7 @@ class OverloadDecoratorBase(metaclass=ABCMeta):
             self.overloader._reg[self.numpy_func] = _Dispatcher()
 
     # @abstractmethod  # TODO: fix when https://github.com/python/mypy/issues/5374 released
-    def _func_hook(self, func: Callable[..., Any]) -> Callable[..., Any]:
+    def func_hook(self, func: Callable[..., Any]) -> Callable[..., Any]:
         raise NotImplementedError
 
     def __call__(self, func: C) -> C:
@@ -215,7 +215,7 @@ class OverloadDecoratorBase(metaclass=ABCMeta):
 
         # Adding a new numpy function
         info = _NumPyInfo(
-            func=self._func_hook(func), types=tinfo, implements=self.numpy_func, dispatch_on=self.dispatch_on
+            func=self.func_hook(func), types=tinfo, implements=self.numpy_func, dispatch_on=self.dispatch_on
         )
         # Register the function
         self.overloader._reg[self.numpy_func]._dispatcher.register(self.dispatch_on, info)
@@ -224,11 +224,11 @@ class OverloadDecoratorBase(metaclass=ABCMeta):
 
 @dataclass(frozen=True)
 class ImplementsDecorator(OverloadDecoratorBase):
-    def _func_hook(self, func: C) -> C:
+    def func_hook(self, func: C) -> C:
         return func
 
 
 @dataclass(frozen=True)
 class AssistsDecorator(OverloadDecoratorBase):
-    def _func_hook(self, func: Callable[..., R]) -> Assists[R]:
+    def func_hook(self, func: Callable[..., R]) -> Assists[R]:
         return Assists(func=func, implements=self.numpy_func, dispatch_on=self.dispatch_on)

--- a/tests/integration/test_array_wrapper.py
+++ b/tests/integration/test_array_wrapper.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Callable
 import numpy as np
 import pytest
 
-# LOCALFOLDER
+# LOCAL
 from overload_numpy import NumPyOverloader
 from overload_numpy.constraints import Covariant
 from overload_numpy.dispatch import _notdispatched_info

--- a/tests/integration/test_array_wrapper.py
+++ b/tests/integration/test_array_wrapper.py
@@ -40,7 +40,7 @@ class Vector1D:
         if func not in VEC_FUNCS:
             return NotImplemented
 
-        # Get _NumPyInfo on function, given type of self
+        # Get _NumPyFuncOverloadInfo on function, given type of self
         finfo = VEC_FUNCS[func](self)
         if not finfo.validate_types(types):
             return NotImplemented

--- a/tests/integration/test_array_wrapper.py
+++ b/tests/integration/test_array_wrapper.py
@@ -94,9 +94,7 @@ def test_entries(overloader, vec1d):
     npinfo = dispatcher(vec1d)
     assert npinfo.func is concatenate
     assert npinfo.implements is np.concatenate
-    assert npinfo.types == {
-        Covariant(Vector1D),
-    }
+    assert npinfo.types == {Covariant(Vector1D)}
 
 
 def test_calling(overloader, vec1d, array):

--- a/tests/unit/test_constraints.py
+++ b/tests/unit/test_constraints.py
@@ -2,7 +2,9 @@
 # IMPORTS
 
 # STDLIB
+import pickle
 from abc import ABCMeta, abstractmethod
+from copy import copy, deepcopy
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -68,6 +70,19 @@ class TypeConstraint_TestBase(metaclass=ABCMeta):
     @abstractmethod
     def test_validate_type(self, constraint, types) -> None:
         pass
+
+    # ===============================================================
+    # Usage Tests
+
+    @pytest.mark.incompatible_with_mypyc
+    def test_serialization(self, constraint) -> None:
+        # copying
+        assert copy(constraint) == constraint
+        assert deepcopy(constraint) == constraint
+
+        # pickling
+        dumps = pickle.dumps(constraint)
+        assert pickle.loads(dumps) == constraint
 
 
 class Test_Invariant(TypeConstraint_TestBase):

--- a/tests/unit/test_constraints.py
+++ b/tests/unit/test_constraints.py
@@ -11,7 +11,7 @@ from typing import Protocol
 # THIRDPARTY
 import pytest
 
-# LOCALFOLDER
+# LOCAL
 from overload_numpy.constraints import (
     Between,
     Contravariant,

--- a/tests/unit/test_dispatch.py
+++ b/tests/unit/test_dispatch.py
@@ -10,7 +10,7 @@ import pytest
 
 # LOCAL
 from overload_numpy.dispatch import _Dispatcher, _notdispatched, _notdispatched_info
-from overload_numpy.npinfo import _NOT_DISPATCHED, _NumPyInfo
+from overload_numpy.npinfo import _NOT_DISPATCHED, _NumPyFuncOverloadInfo
 
 ##############################################################################
 # TESTS
@@ -25,7 +25,7 @@ def test__notdispatched() -> None:
 
 def test__notdispatched_info() -> None:
     """Test :func:`overload_numpy.overload._notdispatched_info`."""
-    assert isinstance(_notdispatched_info, _NumPyInfo)
+    assert isinstance(_notdispatched_info, _NumPyFuncOverloadInfo)
     assert _notdispatched_info.func is _notdispatched
     assert _notdispatched_info.implements is _notdispatched
     assert _notdispatched_info.types is _NOT_DISPATCHED

--- a/tests/unit/test_dispatch.py
+++ b/tests/unit/test_dispatch.py
@@ -8,7 +8,7 @@ from copy import copy, deepcopy
 # THIRDPARTY
 import pytest
 
-# LOCALFOLDER
+# LOCAL
 from overload_numpy.dispatch import _Dispatcher, _notdispatched, _notdispatched_info
 from overload_numpy.npinfo import _NOT_DISPATCHED, _NumPyInfo
 

--- a/tests/unit/test_npinfo.py
+++ b/tests/unit/test_npinfo.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Callable
 import numpy as np
 import pytest
 
-# LOCALFOLDER
+# LOCAL
 from .test_constraints import TypeConstraint_TestBase
 from overload_numpy.constraints import Covariant, Invariant, TypeConstraint
 from overload_numpy.npinfo import _NOT_DISPATCHED, _NotDispatched, _NumPyInfo

--- a/tests/unit/test_npinfo.py
+++ b/tests/unit/test_npinfo.py
@@ -47,10 +47,19 @@ class Test__NotDispatched(TypeConstraint_TestBase):
 
     @pytest.fixture(scope="class")
     def constraint(self, constraint_cls) -> TypeConstraint:
-        return _NOT_DISPATCHED
+        return constraint_cls()
+
+    # ===============================================================
+    # Method Tests
 
     def test_validate_type(self, constraint) -> None:
         assert constraint.validate_type(None) is False
+
+    # ===============================================================
+    # Usage Tests
+
+    def test_instance(self, constraint_cls) -> None:
+        assert isinstance(_NOT_DISPATCHED, constraint_cls)
 
 
 ##############################################################################

--- a/tests/unit/test_overload.py
+++ b/tests/unit/test_overload.py
@@ -3,7 +3,7 @@
 # THIRDPARTY
 import pytest
 
-# LOCALFOLDER
+# LOCAL
 from overload_numpy.overload import NumPyOverloader
 
 

--- a/tests/unit/test_overload.py
+++ b/tests/unit/test_overload.py
@@ -56,9 +56,13 @@ class Test_NumPyOverloader:
     def test_implements(self, overloader):
         pass
 
+    @pytest.mark.skip
+    def test_assists(self, overloader):
+        pass
+
     # ===============================================================
     # Usage tests
 
-    @pytest.mark.skip
+    @pytest.mark.incompatible_with_mypyc
     def test_serialization(self, overloader):
         pass

--- a/tox.ini
+++ b/tox.ini
@@ -105,3 +105,23 @@ commands =
 max-line-length = 120
 ignore = E203, W503
 doctests = True
+
+
+[pytest]
+testpaths =
+    tests
+    src/overload_numpy
+    docs
+astropy_header = True
+doctest_plus = enabled
+text_file_format = rst
+addopts = --doctest-rst
+markers =
+    incompatible_with_mypyc: run when testing mypyc compiled black
+filterwarnings =
+    # tomlkit
+    ignore:The config value
+    # distutils
+    ignore:distutils Version classes are deprecated\.
+doctest_subpackage_requires =
+    overload_numpy/overload.py = python>=3.10


### PR DESCRIPTION
Signed-off-by: nstarman <nstarkman@protonmail.com>

TODO:
- [x] docs
- [x] tests
- [x] changelog

Followup:  Assemble lists of numpy functions with similar inputs & outputs so that overloads can be done with a for loop (or better yet ``@assists(func, ...)`` can accept the whole list).

## Description

``implements`` is for a single numpy func. ``assists`` allows for abstraction over many different numpy funcs with similar inputs & outputs.

```python
VEC_FUNCS = NumPyOverloader()

@dataclass
class Vector1D(overload_numpy.NDFunctionMixin):
    """A simple array wrapper."""

    x: np.ndarray
    NP_FUNC_OVERLOADS: ClassVar[NumPyOverloader] = VEC_FUNCS


array = np.arange(10)
vec1d = Vector1D(array)

@VEC_FUNCS.assists(np.concatenate, types=Vector1D, dispatch_on=Vector1D)
def concatenate_assists(dispatch_on, func, vecs: tuple[Vector1D, ...], *args, **kwargs):
    cls = type(vecs[0])
    if any(not isinstance(type(v), cls) for v in vecs):
            return NotImplemented
    return cls(*(func(tuple(getattr(v, f.name) for v in vec1ds), *args, **kwargs)
                     for f in fields(cls)))

# a bad example because these are ufuncs (not yet supported) and also this is not how vectors work.
@VEC_FUNCS.assists(np.subtract, types=Vector1D, dispatch_on=Vector1D)
@VEC_FUNCS.assists(np.add, types=Vector1D, dispatch_on=Vector1D)
def concatenate_assists(dispatch_on, func, vec1: Vector1D, vec2: Vector1D, *args, **kwargs):
    cls = type(vec1)
    if type(vec2) is not cls:
        return NotImplemented
    return cls(*(func(tuple(getattr(v, f.name) for v in vec1ds), *args, **kwargs)
                     for f in fields(cls)))
```


## PR Checklist

- [ ] Check out the [contributing guidelines](https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md)
- [ ] Check out the [contributing workflow](http://docs.astropy.org/en/latest/development/workflow/development_workflow.html) ( for a practical example [click here](https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example) )
- [ ] Give a detailed description of the PR above.
- [ ] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [ ] Add tests, if applicable, to ensure code coverage never decreases.
- [ ] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [ ] Ensure linear history by rebasing, when requested by the maintainer.
