### PR TITLE
Replace func as key with str

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,13 +4,16 @@ Version 0.1
 New Features
 ------------
 
-- ``_NumPyInfo`` is renamed to ``_NumPyFuncOverloadInfo`` [#16]
+- ``NDFunctionMixin`` now passes the calling type, not the dispach type to
+  ``_Assists`` wrappers. [#22]
+
+- ``_NumPyInfo`` is renamed to ``_NumPyFuncOverloadInfo``. [#16]
 
 - ``dispatch_on`` type information is added to the ``_NumPyFuncOverloadInfo`` object to
   which it dispaches. [#21]
 
 - Arguments to ``TypeConstraint.validate_types`` (and subclasses) are now
-  positional-only [#21]
+  positional-only. [#21]
 
 
 0.0.1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,11 @@ New Features
 - ``NDFunctionMixin`` now passes the calling type, not the dispach type to
   ``_Assists`` wrappers. [#22]
 
-- ``_NumPyInfo`` is renamed to ``_NumPyFuncOverloadInfo``. [#16]
+- ``NumPyFunctionOverloader``'s keys are now the function's module + name, since
+  NumPy sometimes swaps the function behind the scenes, making it a poor choice
+  of key. [#22]
+
+- ``_NumPyInfo`` is renamed to ``_NumPyFuncOverloadInfo`` [#16]
 
 - ``dispatch_on`` type information is added to the ``_NumPyFuncOverloadInfo`` object to
   which it dispaches. [#21]

--- a/src/overload_numpy/assists.py
+++ b/src/overload_numpy/assists.py
@@ -57,7 +57,7 @@ class _Assists(Generic[R]):
     implements: Callable[..., Any]
     """The overloaded :mod:`numpy` function."""
 
-    def __call__(self, *args: Any, **kwargs: Any) -> R:
+    def __call__(self, calling_type: type, /, *args: Any, **kwargs: Any) -> R:
         """
         Call the wrapped function, providing the dispatch type, :mod:`numpy`
         function, and calling args and kwargs.
@@ -74,4 +74,4 @@ class _Assists(Generic[R]):
         ``R``
             The return output type of ``func``.
         """
-        return self.func(self.dispatch_on, self.implements, *args, **kwargs)
+        return self.func(calling_type, self.implements, *args, **kwargs)

--- a/src/overload_numpy/constraints.py
+++ b/src/overload_numpy/constraints.py
@@ -18,7 +18,7 @@ __all__ = ["TypeConstraint", "Invariant", "Covariant", "Contravariant", "Between
 ##############################################################################
 
 
-@mypyc_attr(allow_interpreted_subclasses=True, serializable=True)
+@mypyc_attr(allow_interpreted_subclasses=True)
 class TypeConstraint(metaclass=ABCMeta):
     """ABC for constraining an argument type.
 
@@ -45,7 +45,7 @@ class TypeConstraint(metaclass=ABCMeta):
         """
 
 
-@mypyc_attr(allow_interpreted_subclasses=True, serializable=True)
+@mypyc_attr(allow_interpreted_subclasses=True)
 @dataclass(frozen=True)
 class Invariant(TypeConstraint):
     """Type constraint for invariance -- the exact type.
@@ -79,7 +79,7 @@ class Invariant(TypeConstraint):
         return arg_type is self.bound
 
 
-@mypyc_attr(allow_interpreted_subclasses=True, serializable=True)
+@mypyc_attr(allow_interpreted_subclasses=True)
 @dataclass(frozen=True)
 class Covariant(TypeConstraint):
     """A covariant constraint -- permitting subclasses.
@@ -114,7 +114,7 @@ class Covariant(TypeConstraint):
         return issubclass(arg_type, self.bound)
 
 
-@mypyc_attr(allow_interpreted_subclasses=True, serializable=True)
+@mypyc_attr(allow_interpreted_subclasses=True)
 @dataclass(frozen=True)
 class Contravariant(TypeConstraint):
     """A contravariant constraint -- permitting superclasses.
@@ -148,7 +148,7 @@ class Contravariant(TypeConstraint):
         return issubclass(self.bound, arg_type)
 
 
-@mypyc_attr(allow_interpreted_subclasses=True, serializable=True)
+@mypyc_attr(allow_interpreted_subclasses=True)
 @dataclass(frozen=True)
 class Between(TypeConstraint):
     """Type constrained between two types.

--- a/src/overload_numpy/mixin.py
+++ b/src/overload_numpy/mixin.py
@@ -187,7 +187,7 @@ class NDFunctionMixin:
             The result of calling the overloaded functions.
         """
         # Check if can be dispatched.
-        if func not in self.NP_FUNC_OVERLOADS:
+        if not self.NP_FUNC_OVERLOADS.__contains__(func):
             return NotImplemented
 
         # Get _NumPyFuncOverloadInfo on function, given type of self.

--- a/src/overload_numpy/mixin.py
+++ b/src/overload_numpy/mixin.py
@@ -9,6 +9,9 @@ from typing import TYPE_CHECKING, Any, Callable, ClassVar, Collection
 # THIRDPARTY
 from mypy_extensions import mypyc_attr
 
+# LOCAL
+from overload_numpy.assists import _Assists
+
 if TYPE_CHECKING:
     # LOCAL
     from overload_numpy.constraints import TypeConstraint
@@ -200,4 +203,6 @@ class NDFunctionMixin:
 
         # TODO! validation for args and kwargs.
 
-        return finfo.func(*args, **kwargs)  # returns the result or NotImplemented
+        # Direct impolementation versus assists
+        init_info = (self.__class__,) if isinstance(finfo.func, _Assists) else ()
+        return finfo.func(*init_info, *args, **kwargs)  # Returns result or NotImplemented

--- a/src/overload_numpy/mixin.py
+++ b/src/overload_numpy/mixin.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
 ##############################################################################
 
 
-@mypyc_attr(allow_interpreted_subclasses=True, serializable=True)
+@mypyc_attr(allow_interpreted_subclasses=True)
 class NDFunctionMixin:
     """Mixin for adding |__array_function__| to a class.
 

--- a/src/overload_numpy/npinfo.py
+++ b/src/overload_numpy/npinfo.py
@@ -29,7 +29,7 @@ Self = TypeVar("Self")
 ##############################################################################
 
 
-@mypyc_attr(allow_interpreted_subclasses=True, serializable=True)
+@mypyc_attr(allow_interpreted_subclasses=True)
 @dataclass(frozen=True)
 class _NotDispatched(TypeConstraint):
     """A TypeConstraint that always validates to `False`.

--- a/tests/integration/test_array_wrapper.py
+++ b/tests/integration/test_array_wrapper.py
@@ -81,7 +81,7 @@ def test_entries(overloader, vec1d):
 
     # Only `numpy.add` is registered.
     assert np.concatenate in overloader
-    assert {np.concatenate} == overloader.keys()
+    assert {"numpy.concatenate"} == overloader.keys()
 
     # `numpy` function -> Dispatcher
     dispatcher = overloader[np.concatenate]


### PR DESCRIPTION
## Description

NumPy does weird function replacement in a lot of places, so lookup tables using the function don't work. Thankfully all the substituted functions share the same module and name, so these must be the lookup keys.


## PR Checklist

- [ ] Check out the [contributing guidelines](https://github.com/astropy/astropy/blob/master/CONTRIBUTING.md) and [code of conduct](https://github.com/astropy/astropy/blob/master/CODE_OF_CONDUCT.md)
- [ ] Check out the [contributing workflow](http://docs.astropy.org/en/latest/development/workflow/development_workflow.html) ( for a practical example [click here](https://docs.astropy.org/en/latest/development/workflow/git_edit_workflow_examples.html#astropy-fix-example) )
- [ ] Give a detailed description of the PR above.
- [ ] Document changes in the `CHANGES.rst` file. See existing changelog for examples.
- [ ] Add tests, if applicable, to ensure code coverage never decreases.
- [ ] Make sure the docs are up to date, if applicable, particularly the docstrings and RST files in `docs` folder.
- [ ] Ensure linear history by rebasing, when requested by the maintainer.
